### PR TITLE
remove unused API calls for path/param whitelists

### DIFF
--- a/pysigsci/bin/pysigsci
+++ b/pysigsci/bin/pysigsci
@@ -81,8 +81,8 @@ def main():
                  'events', 'event', 'requests', 'request', 'request-feed',
                  'request-rules', 'signal-rules', 'templated-rules', 'advanced-rules',
                  'rule-lists', 'whitelist', 'blacklist', 'redactions', 'integrations',
-                 'integration', 'parameter-whitelist', 'parameter-whitelist-param',
-                 'path-whitelist', 'path-whitelist-path', 'activity',
+                 'integration', 'parameter-whitelist',
+                 'path-whitelist', 'activity',
                  'header-links', 'header-link', 'site-members', 'site-member',
                  'site-monitor', 'agents', 'agent', 'agent-logs',
                  'suspicious-ips', 'top-attacks', 'timeseries-requests'])
@@ -91,8 +91,8 @@ def main():
         help='Add data via the API.',
         choices=['corp-user', 'custom-alert', 'whitelist', 'blacklist',
                  'request-rules', 'signal-rules', 'custom-signals',
-                 'redaction', 'integration', 'parameter-whitelist',
-                 'path-whitelist', 'header-links', 'site-member'])
+                 'redaction', 'integration',
+                 'header-links', 'site-member'])
     parser.add_argument(
         '--update',
         help='Update data via the API.',
@@ -102,8 +102,8 @@ def main():
         '--delete',
         help='Delete data via the API.',
         choices=['corp-user', 'custom-alert', 'whitelist', 'blacklist',
-                 'redaction', 'integration', 'parameter-whitelst',
-                 'path-whitelist', 'custom-signal', 'header-links', 'site-member'])
+                 'redaction', 'integration',
+                 'custom-signal', 'header-links', 'site-member'])
     parser.add_argument(
         '--power-rules',
         help='Use the power rules repository.',

--- a/pysigsci/sigsciapi/sigsciapi.py
+++ b/pysigsci/sigsciapi/sigsciapi.py
@@ -743,41 +743,6 @@ class SigSciApi(object):
                                                             self.corp,
                                                             self.site))
 
-    def add_parameter_whitelist(self, data):
-        """
-        Add to parameter whitelist
-        https://docs.signalsciences.net/api/#_corps__corpName__sites__siteName__paramwhitelist_post
-        POST /corps/{corpName}/sites/{siteName}/paramwhitelist
-        """
-        return self._make_request(
-            endpoint="{}/{}/sites/{}/paramwhitelist".format(
-                self.ep_corps, self.corp, self.site),
-            json=data,
-            method="POST")
-
-    def get_parameter_whitelist_param(self, identifier):
-        """
-        Get whitelisted parameter by ID
-        https://docs.signalsciences.net/api/#_corps__corpName__sites__siteName__paramwhitelist__paramID__get
-        GET /corps/{corpName}/sites/{siteName}/paramwhitelist/{paramID}
-        """
-        return self._make_request(
-            endpoint="{}/{}/sites/{}/paramwhitelist/{}".format(self.ep_corps,
-                                                               self.corp,
-                                                               self.site,
-                                                               identifier))
-
-    def delete_parameter_whitelist(self, identifier):
-        """
-        Delete from parameter whitelist
-        https://docs.signalsciences.net/api/#_corps__corpName__sites__siteName__paramwhitelist__paramID__delete
-        DELETE /corps/{corpName}/sites/{siteName}/paramwhitelist/{paramID}
-        """
-        return self._make_request(
-            endpoint="{}/{}/sites/{}/paramwhitelist/{}".format(
-                self.ep_corps, self.corp, self.site, identifier),
-            method="DELETE")
-
     # PATH WHITELIST
     def get_path_whitelist(self):
         """
@@ -789,41 +754,6 @@ class SigSciApi(object):
             endpoint="{}/{}/sites/{}/pathwhitelist".format(self.ep_corps,
                                                            self.corp,
                                                            self.site))
-
-    def add_path_whitelist(self, data):
-        """
-        Add to path whitelist
-        https://docs.signalsciences.net/api/#_corps__corpName__sites__siteName__pathwhitelist_post
-        POST /corps/{corpName}/sites/{siteName}/pathwhitelist
-        """
-        return self._make_request(
-            endpoint="{}/{}/sites/{}/pathwhitelist".format(
-                self.ep_corps, self.corp, self.site),
-            json=data,
-            method="POST")
-
-    def get_path_whitelist_path(self, identifier):
-        """
-        Get whitelisted path by ID
-        https://docs.signalsciences.net/api/#_corps__corpName__sites__siteName__pathwhitelist__pathID__get
-        GET /corps/{corpName}/sites/{siteName}/pathwhitelist/{pathID}
-        """
-        return self._make_request(
-            endpoint="{}/{}/sites/{}/pathwhitelist/{}".format(self.ep_corps,
-                                                              self.corp,
-                                                              self.site,
-                                                              identifier))
-
-    def delete_path_whitelist(self, identifier):
-        """
-        Delete from path whitelist
-        https://docs.signalsciences.net/api/#_corps__corpName__sites__siteName__pathwhitelist__pathID__delete
-        DELETE /corps/{corpName}/sites/{siteName}/pathwhitelist/{pathID}
-        """
-        return self._make_request(
-            endpoint="{}/{}/sites/{}/pathwhitelist/{}".format(
-                self.ep_corps, self.corp, self.site, identifier),
-            method="DELETE")
 
     # ACTIVITY
     def get_activity(self):


### PR DESCRIPTION
The calls to add, delete or get an individual whitelisted path/param are unused. We are going to remove them from the API and want to also remove them here.