### PR TITLE
Change content-type for POST

### DIFF
--- a/pysigsci/sigsciapi/sigsciapi.py
+++ b/pysigsci/sigsciapi/sigsciapi.py
@@ -62,6 +62,7 @@ class SigSciApi(object):
         if method == "GET":
             result = requests.get(url, params=params, headers=headers, cookies=cookies)
         elif method == "POST":
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
             result = requests.post(url, data=data, headers=headers, cookies=cookies)
         elif method == "POST_JSON":
             result = requests.post(url, json=json, headers=headers, cookies=cookies)


### PR DESCRIPTION
These methods:
auth
expire_event
generate_site_monitor_url
enable_site_monitor
disable_site_monitor

in particular auth() need to have POST have their Content-Type set
to application/x-www-form-urlencoded in order to function properly.
The library defaults all Content-Type settings to application/json.