### PR TITLE
Added the expand query parameter to get_corp_users

### DIFF
--- a/pysigsci/__init__.py
+++ b/pysigsci/__init__.py
@@ -1,3 +1,3 @@
 """The version string for this application"""
 
-VERSION = "3.17.0"
+VERSION = "3.17.1"

--- a/pysigsci/sigsciapi/sigsciapi.py
+++ b/pysigsci/sigsciapi/sigsciapi.py
@@ -140,14 +140,20 @@ class SigSciApi(object):
             params=parameters)
 
     # CORP USERS
-    def get_corp_users(self):
+    def get_corp_users(self, expand=None):
         """
         List users in corp
-        https://docs.signalsciences.net/api/#list-users-in-corp
+        https://docs.signalsciences.net/api/#_corps__corpName__users_get
         GET /corps/{corpName}/users
         """
-        return self._make_request(
-            endpoint="{}/{}/users".format(self.ep_corps, self.corp))
+        if expand in ['announcements', 'defaultDashboards','memberships']:
+            return self._make_request(
+                endpoint="{}/{}/users?expand={}".format(self.ep_corps, self.corp, expand))
+        elif expand is None:
+            return self._make_request(
+                endpoint="{}/{}/users".format(self.ep_corps, self.corp))
+        else:
+            raise Exception('Improper value passed to expand.')
 
     def get_corp_user(self, email):
         """


### PR DESCRIPTION
Reading [the api docs](https://docs.signalsciences.net/api/#_corps__corpName__users_get) and I discovered that there's been some new "query parameters" added to the signal sciences API.  The `expand` parameter was of particular interest, since it does the recursive work of expanding what used to just be pointers to other API endpoints.

I implemented the basic expand query parameter here since I needed it for something I was working on.

HTH!